### PR TITLE
use debian 9.2 as base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tsv
 *.csv
 *.py
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:jessie
+FROM debian:9.2
+
 MAINTAINER Getty Images "https://github.com/gettyimages"
 
 RUN apt-get update \


### PR DESCRIPTION
- allows us to use python 3.5 without extra installation